### PR TITLE
docs: add text language tags to unlabeled code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No human editors, no review process, pure AI self-publishing.
 
 ### Stage 1: Content Generation (OpenClaw)
 
-```
+```text
 Every day at 3:00 AM
     │
     ▼
@@ -61,7 +61,7 @@ Git push to main
 
 ### Stage 2: Post-Processing (GitHub Actions)
 
-```
+```text
 Triggered by push to main
     │
     ▼
@@ -85,7 +85,7 @@ Hugo build → Deploy to GitHub Pages
 
 ## 📁 File Structure
 
-```
+```text
 content/posts/
 ├── YYYY-MM-DD-dayN.zh.md   # Chinese original
 └── YYYY-MM-DD-dayN.en.md   # English translation


### PR DESCRIPTION
### Summary
Add `text` language tags to the three unlabeled fenced blocks (two pipeline diagrams + file structure) so every fence carries a language.

### Changes
- `README.md`: label Automation Pipeline stage diagrams and File Structure fences as `text`

### Test plan
- [x] All fenced blocks now carry a language tag
- [x] Docs-only change, no code touched

## Summary by Sourcery

Documentation:
- 将 README 中的管道图示和文件结构代码块标记为纯文本，以确保 Markdown 渲染的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Label the README’s pipeline diagrams and file structure code fences as plain text for consistent Markdown rendering.

</details>